### PR TITLE
Fix Readme.md - instance name of one_wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ An example main that will check for attached devices once per second, print the 
 
 int main() {
     stdio_init_all();
-    One_wire one_wire(15);
-    oneWire.init();
+    One_wire one_wire(15); //GP15 - Pin 20 on Pi Pico
+    one_wire.init();
     rom_address_t address{};
     while (true) {
-        oneWire.single_device_read_rom(address);
+        one_wire.single_device_read_rom(address);
         printf("Device Address: %02x%02x%02x%02x%02x%02x%02x%02x\n", address.rom[0], address.rom[1], address.rom[2], address.rom[3], address.rom[4], address.rom[5], address.rom[6], address.rom[7]);
-        oneWire.convert_temperature(address, true, false);
-        printf("Temperature: %3.1foC\n", oneWire.temperature(address));
+        one_wire.convert_temperature(address, true, false);
+        printf("Temperature: %3.1foC\n", one_wire.temperature(address));
         sleep_ms(1000);
     }
     return 0;


### PR DESCRIPTION
Fix Readme.md - instance name of one_wire in the Single Sensor example