### PR TITLE
added Cmake file to allow easy use of library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(pico-onewire-lib INTERFACE)
+target_include_directories(pico-onewire-lib INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(pico-onewire-lib INTERFACE hardware_flash)
+target_sources(pico-onewire-lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/source/one_wire.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/one_wire.h
+)
+


### PR DESCRIPTION
I may misunderstand how this works, but shouldn't there be a CMakeLists.txt file in the root of the repo so that it can be added to a project as a submodule then simply included as a subdirectory?

Either way, I had to create this file to get my repo to compile when using yours as a subdirectory so I thought it might be useful to add to your repo.