### PR TITLE
Optimize search for devices, following more closely the algorithm on Maxim APP 187

### DIFF
--- a/api/one_wire.h
+++ b/api/one_wire.h
@@ -180,6 +180,9 @@ private:
 	bool _power_polarity;
 	uint8_t ram[9]{};
 
+	int _last_discrepancy;	// search state
+	bool _last_device;  // search state
+
 	static uint8_t crc_byte(uint8_t crc, uint8_t byte);
 
 	static void bit_write(uint8_t &value, int bit, bool set);


### PR DESCRIPTION
'search_rom_find_next()' was always starting the search from the beginning and ignoring devices already found. With these changes, 'search_rom_find_next' will start from the previous address found and no checks for duplicates are needed. If there are many devices in the 1-wire network, this can significantly reduce the time for finding the addresses.
