### PR TITLE
Added ToUint64 convertor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ int main() {
 A more complicated example to print all the available devices.
 Additionally pin 22 is used to exit the main loop and return to the USB Flashing mode.
 A push button switch between pins 28&29 (GND+GP22) will do nicely.
+Also we are converting the address to uint64 for future use.
 
 Add to the CMakeLists.txt in your project config:
 ```
@@ -87,9 +88,7 @@ int main() {
 		one_wire.convert_temperature(null_address, true, true);
 		for (int i = 0; i < count; i++) {
 			auto address = One_wire::get_address(i);
-			printf("Address: %02x%02x%02x%02x%02x%02x%02x%02x\r\n", address.rom[0], address.rom[1], address.rom[2],
-				   address.rom[3], address.rom[4], address.rom[5], address.rom[6], address.rom[7]);
-			printf("Temperature: %3.1foC\n", one_wire.temperature(address));
+			printf("%016llX\t%3.1f*C\r\n", One_wire::to_uint64(address), one_wire.temperature(address));
 		}
 		sleep_ms(1000);
 	}

--- a/api/one_wire.h
+++ b/api/one_wire.h
@@ -141,6 +141,15 @@ public:
 	int convert_temperature(rom_address_t &address, bool wait, bool all);
 
 	/**
+	 * Changes the "endianness" of the unique device ID in supplied address
+	 * so that it can be conveniently printed out and manipulated as a number.
+	 *
+	 * @param address the address you received from OneWire::get_address(i).
+	 * @returns device ID as unsigned 64-bit integer.
+	 */
+	static uint64_t to_uint64(rom_address_t &address);
+
+	/**
 	 * This function will return the temperature measured by the specific device.
 	 *
 	 * @param convert_to_fahrenheit whether to convert the degC to Fahrenheit

--- a/source/one_wire.cpp
+++ b/source/one_wire.cpp
@@ -395,6 +395,17 @@ void One_wire::write_scratch_pad(rom_address_t &address, int data) {
 	}
 }
 
+uint64_t One_wire::to_uint64(rom_address_t &address) {
+        return  ((uint64_t)address.rom[7])        |
+               (((uint64_t)address.rom[6]) << 8 ) |
+               (((uint64_t)address.rom[5]) << 16) |
+               (((uint64_t)address.rom[4]) << 24) |
+               (((uint64_t)address.rom[3]) << 32) |
+               (((uint64_t)address.rom[2]) << 40) |
+               (((uint64_t)address.rom[1]) << 48) |
+               (((uint64_t)address.rom[0]) << 56);
+}
+
 float One_wire::temperature(rom_address_t &address, bool convert_to_fahrenheit) {
 	float answer, remaining_count, count_per_degree;
 	int reading;


### PR DESCRIPTION
The address is returned from the protocol in the inverted endiannes which calls for the complicated code while printing and disallows to manage sensors at scale if they are purchased from the same batch.

Adding here a convenience method that converts the address rom array into a UInt64 which can be:

- easily printf'ed with `%016llX` (example provided in readme)
- manipulated as a regular number

I tried to follow your style.